### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,12 +36,12 @@ Channels-based desktop notification system
 Documentation
 -------------
 
-The full documentation is at https://django-knocker.readthedocs.org.
+The full documentation is at https://django-knocker.readthedocs.io.
 
 Usage
 -----
 
-See http://django-knocker.readthedocs.org/en/latest/usage.html
+See https://django-knocker.readthedocs.io/en/latest/usage.html
 
 Features
 --------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -87,4 +87,4 @@ Methods
 .. _django-parler: https://github.com/edoburu/django-parler
 .. _django-meta: https://github.com/nephila/django-meta
 .. _channels: https://github.com/andrewgodwin/channels
-.. _channels documentation: http://channels.readthedocs.org/en/latest/deploying.html
+.. _channels documentation: https://channels.readthedocs.io/en/latest/deploying.html


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.